### PR TITLE
Fixing an error of no features getting detected for certain images

### DIFF
--- a/qatm_pytorch.ipynb
+++ b/qatm_pytorch.ipynb
@@ -542,7 +542,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.6.4"
   }
  },
  "nbformat": 4,

--- a/qatm_pytorch.ipynb
+++ b/qatm_pytorch.ipynb
@@ -546,5 +546,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 2
 }

--- a/qatm_pytorch.ipynb
+++ b/qatm_pytorch.ipynb
@@ -147,13 +147,14 @@
     "    def __call__(self, x1, x2):\n",
     "        bs, _ , H, W = x1.size()\n",
     "        _, _, h, w = x2.size()\n",
+    "        eps = 1e-12\n",
     "        x1 = x1.view(bs, -1, H*W)\n",
     "        x2 = x2.view(bs, -1, h*w)\n",
     "        concat = torch.cat((x1, x2), dim=2)\n",
     "        x_mean = torch.mean(concat, dim=2, keepdim=True)\n",
     "        x_std = torch.std(concat, dim=2, keepdim=True)\n",
-    "        x1 = (x1 - x_mean) / x_std\n",
-    "        x2 = (x2 - x_mean) / x_std\n",
+    "        x1 = (x1 - x_mean) / (x_std + eps)\n",
+    "        x2 = (x2 - x_mean) / (x_std + eps)\n",
     "        x1 = x1.view(bs, -1, H, W)\n",
     "        x2 = x2.view(bs, -1, h, w)\n",
     "        return [x1, x2]"
@@ -541,9 +542,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/qatm_pytorch.py
+++ b/qatm_pytorch.py
@@ -119,13 +119,14 @@ class MyNormLayer():
     def __call__(self, x1, x2):
         bs, _ , H, W = x1.size()
         _, _, h, w = x2.size()
+        eps = 1e-12
         x1 = x1.view(bs, -1, H*W)
         x2 = x2.view(bs, -1, h*w)
         concat = torch.cat((x1, x2), dim=2)
         x_mean = torch.mean(concat, dim=2, keepdim=True)
         x_std = torch.std(concat, dim=2, keepdim=True)
-        x1 = (x1 - x_mean) / x_std
-        x2 = (x2 - x_mean) / x_std
+        x1 = (x1 - x_mean) / (x_std + eps)
+        x2 = (x2 - x_mean) / (x_std + eps)
         x1 = x1.view(bs, -1, H, W)
         x2 = x2.view(bs, -1, h, w)
         return [x1, x2]


### PR DESCRIPTION
In some 1 -> 1 matching scenarios, no features are detected, as the Tensor returned by the Normalization method (`MyNormLayer`) has NaNs in it. The fix is to just add an epsilon while normalizing, as a zero standard deviation is common for several kinds of images. 